### PR TITLE
fix picking null obj, customisable background colour, loading model after dom loaded.

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -107,14 +107,14 @@ function PV(domElement, opts) {
   this._domElement.appendChild(this._canvas);
   this._domElement.appendChild(this._textureCanvas);
 
-  if (document.readyState == "complete" 
-    || document.readyState == "loaded" 
-      || document.readyState == "interactive") {
-  	this._initPV();
-	} else {
-  	document.addEventListener('DOMContentLoaded', bind(this, this._initPV));
-	}
-};
+  if (document.readyState === "complete" ||  
+    document.readyState === "loaded" ||  
+      document.readyState === "interactive") {
+    this._initPV();
+  } else {
+    document.addEventListener('DOMContentLoaded', bind(this, this._initPV));
+  }
+}
   
 
 // resizes the canvas, separated out from PV.resize because we want


### PR DESCRIPTION
-fix loss of camera control when null pick (e.g double click background)
-add customisable background colour as option
-support loading model after dom as loaded - added a check to see if page loading is already taking place, otherwise _initPV never gets called.
