### PR TITLE
Create mouse down events

### DIFF
--- a/doc/viewer.rst
+++ b/doc/viewer.rst
@@ -7,6 +7,7 @@ The 3D molecules are managed and rendered by an instance of the viewer class. It
  * :ref:`pv.viewer.init`
  * :ref:`pv.viewer.rendering`
  * :ref:`pv.viewer.camera`
+ * :ref:`pv.viewer.events`
  * :ref:`pv.viewer.management`
 
 
@@ -196,6 +197,49 @@ Proteins come in all sizes and shapes. For optimal viewing, some camera paramete
 
 
 
+.. _pv.viewer.events:
+
+Viewer Events
+---------------------------------------------------------------------------------
+Mouse selection events are fired when the user clicks or double clicks a residue/atom. 
+
+.. function:: pv.Viewer.addListener(type, callback)
+
+  Add a new listener for *atomClicked* or *atomDoubleClicked* events.
+
+  :param type: The type of event to listen to. Must be either 'atomClicked' or 'atomDoubleClicked' 
+  :param callback: The function to receive the callback. type of event to listen to. Must be either 'atomClicked' or 'atomDoubleClicked' The arguments of the callback function is *picked*, and *originalEvent* which is the mouse event. 
+
+  The following code shows how to listen for double click events to either make the selection the focal point and center of zoom, or zoom out to the whole structure if the background is double clicked. 
+  .. code-block:: javascript
+    var structure = .... // point to what you want the default background selection to view
+    viewer.addListener("atomDoubleClicked", function(picked, originalEvent) {
+      if (picked === null) {
+        viewer.fitTo(structure);
+      }
+      else {
+        var transformedPos = vec3.create();
+        var newAtom = picked.object().atom;
+        var pos = newAtom.pos();
+        if (picked.transform()) {
+          vec3.transformMat4(transformedPos, pos, picked.transform());
+          viewer.setCenter(transformedPos, 500);
+        } else {
+          viewer.setCenter(pos, 500);
+        }
+      }
+    });
+
+  .. code-block:: javascript
+    viewer.addListener("atomClicked", function(picked, originalEvent) {
+  
+      if (picked) {
+        var newAtom = picked.object().atom;
+        var geom = picked.object().geom;
+        
+        console.log(" Residue number=" + newAtom.residue().num());
+      }
+    });
 
 .. _pv.viewer.management:
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -81,6 +81,7 @@ function PV(domElement, opts) {
   this._redrawRequested = false;
   this._resize = false;
   this._lastTimestamp = null;
+  this.listenerMap = {};
   // NOTE: make sure to only request features supported by all browsers,
   // not only browsers that support WebGL in this constructor. WebGL
   // detection only happens in PV._initGL. Once this happened, we are
@@ -496,40 +497,33 @@ PV.prototype._mouseWheelFF = function(event) {
 };
 
 PV.prototype._mouseDoubleClick = (function() {
-  var transformedPos = vec3.create();
   return function(event) {
     var rect = this._canvas.getBoundingClientRect();
     var picked = this.pick(
         { x : event.clientX - rect.left, y : event.clientY - rect.top });
-    if (picked) {
-      var pos = picked.object().atom.pos();
-      if (picked.transform()) {
-        vec3.transformMat4(transformedPos, pos, picked.transform());
-        this.setCenter(transformedPos, this._options.animateTime);
-      } else {
-        this.setCenter(pos, this._options.animateTime);
-        }
-    }
     this._dispatchPickedEvent(event, 'atomDoubleClicked', picked);
     this.requestRedraw();
   };
 })();
 
-PV.prototype._dispatchPickedEvent = function(event, newEventName, picked) {
-  var atomPickedEvent = new CustomEvent(
-      newEventName, 
-      {
-        detail: {
-          atom: picked ? picked.object().atom : null,
-          originalEvent: event,
-          geom: picked ? picked.object().geom : null
-        },
-        bubbles: true,
-        cancelable: true
-      }
-    );
-  this._domElement.dispatchEvent(atomPickedEvent);
 
+PV.prototype.addListener = function(eventName, callback) {
+  var callbacks = this.listenerMap[eventName];
+  if (typeof callbacks === 'undefined') {
+    callbacks = [];
+    this.listenerMap[eventName] = callbacks;
+  }
+  callbacks.push(callback);
+};
+
+PV.prototype._dispatchPickedEvent = function(event, newEventName, picked) {
+  var callbacks = this.listenerMap[newEventName];
+  if (callbacks) {
+    
+    callbacks.forEach(function (callback) {
+      callback(picked, event);
+    });
+  }
 };
 
 PV.prototype._mouseDown = function(event) {
@@ -543,7 +537,7 @@ PV.prototype._mouseDown = function(event) {
     var rect = this._canvas.getBoundingClientRect();
     var picked = this.pick(
         { x : event.clientX - rect.left, y : event.clientY - rect.top });
-    this._dispatchPickedEvent(event, 'atomSelected', picked);
+    this._dispatchPickedEvent(event, 'atomClicked', picked);
   }
   event.preventDefault();
   if (event.shiftKey === true) {


### PR DESCRIPTION
adds an atom picked event to be sent to the dom element.

This can allow highlighting of selected residue etc from the application. 

This is some example code to show how to access the events

<code>var callback = function(e) {
    e.preventDefault();  
    console.log(" Atom number=" + e.detail.atom.residue().num());
};
viewer._domElement.addEventListener("atomSelected", callback, false);
</code>
