### PR TITLE
allow containsResidue for ResidueView so an individual residue can be rendered.

### DIFF
--- a/src/mol.js
+++ b/src/mol.js
@@ -1006,6 +1006,10 @@ ResidueView.prototype.qualifiedName = function() {
   return this._residue.qualifiedName();
 };
 
+ResidueView.prototype.containsResidue = function(residue) {
+  return this._residue.full() === residue.full();
+};
+
 
 
 function AtomView(resView, atom) {


### PR DESCRIPTION
Without this colouring a single residue didn't work with a residueView.

<code>
  var view = new mol.MolView(structure.full());
  var chainView = view.addChain(newResidue.chain(), false);
  var residueView = chainView.addResidue(newResidue, false);
  that.geom.colorBy(color.uniform('white'), residueView);
</code>
