### PR TITLE
Residue view rendering for lines

### DIFF
--- a/src/mol.js
+++ b/src/mol.js
@@ -494,8 +494,8 @@ ResidueBase.prototype.isWater = function() {
 
 ResidueBase.prototype.eachAtom = function(callback, index) {
   index |= 0;
-  for (var i =0; i< this._atoms.length; i+=1) {
-    if (callback(this._atoms[i], index) === false) {
+  for (var i =0; i< this.full()._atoms.length; i+=1) {
+    if (callback(this.full()._atoms[i], index) === false) {
       return false;
     }
     index +=1;
@@ -516,6 +516,11 @@ ResidueBase.prototype.atom = function(index_or_name) {
     }
   }
   return this._atoms[index_or_name]; 
+};
+
+ResidueBase.prototype.atomCount = function() {
+  var count = this.full()._atoms.length;
+  return count;
 };
 
 


### PR DESCRIPTION
ResidueView rendering of a structure drawn in Lines had an issue in the recolor method as it tried to get the atoms for the residue, but only got the fake residueView atoms (this._atoms of the view which was an empty array) instead of its real Residue atoms.

I'm not sure if accessing the full residue in eachAtom is the best place for this to be done. Should all references to _atoms get it from the full() function?
