### PR TITLE
Fix hex colour conversion

### DIFF
--- a/src/shade.js
+++ b/src/shade.js
@@ -80,7 +80,7 @@ exports.forceRGB = function(color) {
         r = parseInt(color[1], 16);
         g = parseInt(color[2], 16);
         b = parseInt(color[3], 16);
-        a = 1.0;
+        a = 15;
         if(color.length===5) {
           a = parseInt(color[4], 16);
         }
@@ -91,6 +91,7 @@ exports.forceRGB = function(color) {
         r = parseInt(color.substr(1, 2), 16);
         g = parseInt(color.substr(3, 2), 16);
         b = parseInt(color.substr(5, 2), 16);
+        a = 255;
         if(color.length===9) {
           a = parseInt(color.substr(7, 2), 16);
         }


### PR DESCRIPTION
The alpha value was not set for 7  size colours (e.g. #FFFFFF).  In 4 size colour, it was set as a normalised value of 1, when it should be the max 255, as it gets normalised later.
