### PR TITLE
Allow to customize colors.

### DIFF
--- a/src/shade.js
+++ b/src/shade.js
@@ -39,32 +39,67 @@ exports.rgb.mix = function(out, colorOne, colorTwo, t) {
 };
 
 var COLORS = {
-  white :        rgb.fromValues(1.0,1.0 ,1.0,1.0),
-  black :        rgb.fromValues(0.0,0.0 ,0.0,1.0),
-  grey :         rgb.fromValues(0.5,0.5 ,0.5,1.0),
-  lightgrey :    rgb.fromValues(0.8,0.8 ,0.8,1.0),
-  darkgrey :     rgb.fromValues(0.3,0.3 ,0.3,1.0),
-  red :          rgb.fromValues(1.0,0.0 ,0.0,1.0),
-  darkred :      rgb.fromValues(0.5,0.0 ,0.0,1.0),
-  lightred :     rgb.fromValues(1.0,0.5 ,0.5,1.0),
-  green :        rgb.fromValues(0.0,1.0 ,0.0,1.0),
-  darkgreen :    rgb.fromValues(0.0,0.5 ,0.0,1.0),
-  lightgreen :   rgb.fromValues(0.5,1.0 ,0.5,1.0),
-  blue :         rgb.fromValues(0.0,0.0 ,1.0,1.0),
-  darkblue :     rgb.fromValues(0.0,0.0 ,0.5,1.0),
-  lightblue :    rgb.fromValues(0.5,0.5 ,1.0,1.0),
-  yellow :       rgb.fromValues(1.0,1.0 ,0.0,1.0),
-  darkyellow :   rgb.fromValues(0.5,0.5 ,0.0,1.0),
-  lightyellow :  rgb.fromValues(1.0,1.0 ,0.5,1.0),
-  cyan :         rgb.fromValues(0.0,1.0 ,1.0,1.0),
-  darkcyan :     rgb.fromValues(0.0,0.5 ,0.5,1.0),
-  lightcyan :    rgb.fromValues(0.5,1.0 ,1.0,1.0),
-  magenta :      rgb.fromValues(1.0,0.0 ,1.0,1.0),
-  darkmagenta :  rgb.fromValues(0.5,0.0 ,0.5,1.0),
-  lightmagenta : rgb.fromValues(1.0,0.5 ,1.0,1.0),
-  orange :       rgb.fromValues(1.0,0.5 ,0.0,1.0),
-  darkorange :   rgb.fromValues(0.5,0.25,0.0,1.0),
-  lightorange :  rgb.fromValues(1.0,0.75,0.5,1.0)
+    white :        rgb.fromValues(1.0,1.0 ,1.0,1.0),
+    black :        rgb.fromValues(0.0,0.0 ,0.0,1.0),
+    grey :         rgb.fromValues(0.5,0.5 ,0.5,1.0),
+    lightgrey :    rgb.fromValues(0.8,0.8 ,0.8,1.0),
+    darkgrey :     rgb.fromValues(0.3,0.3 ,0.3,1.0),
+    red :          rgb.fromValues(1.0,0.0 ,0.0,1.0),
+    darkred :      rgb.fromValues(0.5,0.0 ,0.0,1.0),
+    lightred :     rgb.fromValues(1.0,0.5 ,0.5,1.0),
+    green :        rgb.fromValues(0.0,1.0 ,0.0,1.0),
+    darkgreen :    rgb.fromValues(0.0,0.5 ,0.0,1.0),
+    lightgreen :   rgb.fromValues(0.5,1.0 ,0.5,1.0),
+    blue :         rgb.fromValues(0.0,0.0 ,1.0,1.0),
+    darkblue :     rgb.fromValues(0.0,0.0 ,0.5,1.0),
+    lightblue :    rgb.fromValues(0.5,0.5 ,1.0,1.0),
+    yellow :       rgb.fromValues(1.0,1.0 ,0.0,1.0),
+    darkyellow :   rgb.fromValues(0.5,0.5 ,0.0,1.0),
+    lightyellow :  rgb.fromValues(1.0,1.0 ,0.5,1.0),
+    cyan :         rgb.fromValues(0.0,1.0 ,1.0,1.0),
+    darkcyan :     rgb.fromValues(0.0,0.5 ,0.5,1.0),
+    lightcyan :    rgb.fromValues(0.5,1.0 ,1.0,1.0),
+    magenta :      rgb.fromValues(1.0,0.0 ,1.0,1.0),
+    darkmagenta :  rgb.fromValues(0.5,0.0 ,0.5,1.0),
+    lightmagenta : rgb.fromValues(1.0,0.5 ,1.0,1.0),
+    orange :       rgb.fromValues(1.0,0.5 ,0.0,1.0),
+    darkorange :   rgb.fromValues(0.5,0.25,0.0,1.0),
+    lightorange :  rgb.fromValues(1.0,0.75,0.5,1.0)
+  };
+
+
+  exports.rgb.hex2rgb = function(color){
+    var r, g, b, a;
+    if (color.length === 4 || color.length === 5 ) {
+      r = parseInt(color[1], 16);
+      g = parseInt(color[2], 16);
+      b = parseInt(color[3], 16);
+      a = 15;
+      if(color.length===5) {
+        a = parseInt(color[4], 16);
+      }
+      var oneOver15 = 1/15.0;
+      return rgb.fromValues(oneOver15 * r, oneOver15 * g, oneOver15 * b, oneOver15 * a);
+    }
+    if (color.length === 7 || color.length === 9) {
+      r = parseInt(color.substr(1, 2), 16);
+      g = parseInt(color.substr(3, 2), 16);
+      b = parseInt(color.substr(5, 2), 16);
+      a = 255;
+      if(color.length===9) {
+        a = parseInt(color.substr(7, 2), 16);
+      }
+      var oneOver255 = 1/255.0;
+      return rgb.fromValues(oneOver255 * r, oneOver255 * g, oneOver255 * b, oneOver255 * a);
+    }
+  }
+  
+
+  // provide an override of the default color setting.
+exports.rgb.setColors = function(customColors){
+  console.log("setting colors");
+    COLORS = customColors;
+  exports.initGradients();
 };
 
 // converts color strings to RGB. for now only supports color names. 
@@ -76,29 +111,7 @@ exports.forceRGB = function(color) {
       return lookup;
     }
     if (color.length > 0 && color[0] === '#') {
-      var r, g, b, a;
-      if (color.length === 4 || color.length === 5 ) {
-        r = parseInt(color[1], 16);
-        g = parseInt(color[2], 16);
-        b = parseInt(color[3], 16);
-        a = 15;
-        if(color.length===5) {
-          a = parseInt(color[4], 16);
-        }
-        var oneOver15 = 1/15.0;
-        return rgb.fromValues(oneOver15 * r, oneOver15 * g, oneOver15 * b, oneOver15 * a);
-      }
-      if (color.length === 7 || color.length === 9) {
-        r = parseInt(color.substr(1, 2), 16);
-        g = parseInt(color.substr(3, 2), 16);
-        b = parseInt(color.substr(5, 2), 16);
-        a = 255;
-        if(color.length===9) {
-          a = parseInt(color.substr(7, 2), 16);
-        }
-        var oneOver255 = 1/255.0;
-        return rgb.fromValues(oneOver255 * r, oneOver255 * g, oneOver255 * b, oneOver255 * a);
-      }
+     return rgb.hex2rgb(color);
     }
   }
   // in case no alpha component is provided, default alpha to 1.0
@@ -166,12 +179,14 @@ exports.gradient = function(colors, stops) {
 };
 var gradient = exports.gradient;
 
-GRADIENTS.rainbow =gradient(['red', 'yellow', 'green', 'blue']);
-GRADIENTS.reds = gradient(['lightred', 'darkred']);
-GRADIENTS.greens = gradient(['lightgreen', 'darkgreen']);
-GRADIENTS.blues = gradient(['lightblue', 'darkblue']);
-GRADIENTS.trafficlight = gradient(['green', 'yellow', 'red']);
-GRADIENTS.heatmap = gradient(['red', 'white', 'blue']);
+exports.initGradients = function() {
+  GRADIENTS.rainbow = gradient(['red', 'yellow', 'green', 'blue']);
+  GRADIENTS.reds = gradient(['lightred', 'darkred']);
+  GRADIENTS.greens = gradient(['lightgreen', 'darkgreen']);
+  GRADIENTS.blues = gradient(['lightblue', 'darkblue']);
+  GRADIENTS.trafficlight = gradient(['green', 'yellow', 'red']);
+  GRADIENTS.heatmap = gradient(['red', 'white', 'blue']);
+}
 
 function ColorOp(colorFunc, beginFunc, endFunc) {
   this.colorFor = colorFunc;


### PR DESCRIPTION
This patch allows to customize colors. E.g. the following colors are supposed to be more "color-blind" friendly. This patch also adds support for specifying colors using hex codes.

```javascript
   var myColors = {
        white :        rgb.fromValues(1.0,1.0 ,1.0,1.0),
        black :        rgb.fromValues(0.0,0.0 ,0.0,1.0),
        grey :         rgb.fromValues(0.5,0.5 ,0.5,1.0),
        lightgrey :    rgb.fromValues(0.8,0.8 ,0.8,1.0),
        darkgrey :     rgb.fromValues(0.3,0.3 ,0.3,1.0),
        red :          rgb.hex2rgb("#AA00A2"),
        darkred :      rgb.hex2rgb("#7F207B"),
        lightred :     rgb.fromValues(1.0,0.5 ,0.5,1.0),
        green :        rgb.hex2rgb("#C9F600"),
        darkgreen :    rgb.hex2rgb("#9FB82E"),
        lightgreen :   rgb.hex2rgb("#E1FA71"), // or D8FA3F
        blue :         rgb.hex2rgb("#6A93D4"), // or 6A93D4
        darkblue :     rgb.hex2rgb("#284A7E"), // or 104BA9
        lightblue :    rgb.fromValues(0.5,0.5 ,1.0,1.0),
        yellow :       rgb.hex2rgb("#FFCC73"),
        darkyellow :   rgb.fromValues(0.5,0.5 ,0.0,1.0),
        lightyellow :  rgb.fromValues(1.0,1.0 ,0.5,1.0),
        cyan :         rgb.fromValues(0.0,1.0 ,1.0,1.0),
        darkcyan :     rgb.fromValues(0.0,0.5 ,0.5,1.0),
        lightcyan :    rgb.fromValues(0.5,1.0 ,1.0,1.0),
        magenta :      rgb.fromValues(1.0,0.0 ,1.0,1.0),
        darkmagenta :  rgb.fromValues(0.5,0.0 ,0.5,1.0),
        lightmagenta : rgb.fromValues(1.0,0.5 ,1.0,1.0),
        orange :       rgb.hex2rgb("#FFA200"), // or FFBA40
        darkorange :   rgb.fromValues(0.5,0.25,0.0,1.0),
        lightorange :  rgb.fromValues(1.0,0.75,0.5,1.0),
        brown :        rgb.hex2rgb("#A66A00"),
        purple :       rgb.hex2rgb("#D435CD")
    };

    rgb.setColors(myColors);
```