### PR TITLE
Use relative path to load 1nmr.pdb file

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -198,7 +198,7 @@ function cross() {
 }
 
 function ensemble() {
-  io.fetchPdb('/pdbs/1nmr.pdb', function(structures) {
+  io.fetchPdb('pdbs/1nmr.pdb', function(structures) {
     viewer.clear()
     structure = structures[i];
     for (var i = 0; i < structures.length; ++i) {


### PR DESCRIPTION
Use relative path to work when running under something like "localhost/myproject/" (will look at myproject/pdbs/1nmr.pdb). Otherwise the function can't find the file.