### PR TITLE
add high precision shaders for Android

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -96,7 +96,7 @@ function isAndroid() {
 function shouldUseHighPrecision() {
   // high precision for shaders is only required on iOS, all the other browsers 
   // are doing just fine with mediump.
-  return isiOS();
+  return isiOS() || isAndroid();
 }
 
 var requestAnimFrame = (function(){


### PR DESCRIPTION
Added `isAndroid()` test to `shouldUseHighPrecision` because I found that my Android OS 5.1 device does not render 'webgl' contexts with `mediump`.