### PR TITLE
override manualAntialiasing

### DIFF
--- a/doc/viewer.rst
+++ b/doc/viewer.rst
@@ -23,6 +23,7 @@ Initialization and Configuration
   * *width* The width (in pixels) of the viewer. The special value 'auto' can be used to set the width to the width of the parent element. Defaults to 500.
   * *height* The height (in pixels) of the viewer. The special value 'auto' can be used to set the height to the height of the parent element. Defaults to 500.
   * *antialias*: whether full-scene antialiasing should be enabled. When available, antialiasing will use the built-in WebGL antialiasing. When not, it will fall back to a manual supersampling of the scene. Enabling antialiasing improve the visual results considerably, but also slows down rendering. When rendering speed is a concern, the *antialias* option should be set to false. Defaults to false.
+  * *forceManualAntialiasing*: whether manual antialiasing should be enabled. Defaults to true. 
   * *quality* the level of detail for the geometry. Accepted values are *low*, *medium*, and *high*. See :func:`~pv.Viewer.quality` for a description of these values. Defaults to *low*.
   * *slabMode* sets the default slab mode for the viewer. See :func:`~pv.Viewer.slabMode` for possible values. Defaults to 'auto'.
   * *background* set the default background color of the viewer. Defaults to 'white'. See :ref:`pv.color.notation`

--- a/src/gfx/canvas.js
+++ b/src/gfx/canvas.js
@@ -147,8 +147,8 @@ Canvas.prototype = {
     }
 
     var gl = this._gl;
-    if ((!gl.getContextAttributes().antialias || 
-         this._forceManualAntialiasing) && this._antialias) {
+    if (!gl.getContextAttributes().antialias && 
+        this._forceManualAntialiasing && this._antialias) {
       samples = 2;
     }
     this._realWidth = this._width * samples;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -264,6 +264,7 @@ Viewer.prototype = {
       height : (opts.height || 500),
       animateTime : (opts.animateTime || 0),
       antialias : opts.antialias,
+      forceManualAntialiasing: optValue(opts, 'forceManualAntialiasing', true),
       quality : optValue(opts, 'quality', 'low'),
       style : optValue(opts, 'style', 'hemilight'),
       background : color.forceRGB(opts.background || 'white'),
@@ -492,6 +493,7 @@ Viewer.prototype = {
   _initCanvas : function() {
     var canvasOptions = {
       antialias : this._options.antialias,
+      forceManualAntialiasing: this._options.forceManualAntialiasing,
       height : this._options.height,
       width : this._options.width,
       backgroundColor : this._options.background


### PR DESCRIPTION
`forceManualAntialiasing` causes Pv to render at 1/4 size on mobile (`samples = 2`). This commit allows the user to override that by passing an option.