### PR TITLE
Add grad param for Color.byElement & Color.bySS

### DIFF
--- a/doc/coloring.rst
+++ b/doc/coloring.rst
@@ -48,11 +48,11 @@ The following color operations are available:
   :param gradient: The graident to draw colors from. Defaults to rainbow.
   :param coilColor: The color for residues without regular secondary structure. Defaults to lightgrey.
 
-.. function:: pv.color.bySS([gradient])
+.. function:: pv.color.bySS([palette])
 
   Colors the structure based on secondary structure type of the residue. Distinct colors are used for helices, strands and coil residues.
 
-  :param gradient: An optional gradient to draw colors from. Defaults to lightgrey, blue, green gradient.
+  :param palette: An optional `gradient` or `object` to draw colors from. Object must include `C`, `H`, `E` fields. Defaults to lightgrey, blue, green.
 
 
 .. function:: pv.color.rainbow([gradient])

--- a/doc/coloring.rst
+++ b/doc/coloring.rst
@@ -26,9 +26,11 @@ The following color operations are available:
 
   :param color: a valid color identifier, or rgb instance to be used for the structure. Defaults to red.
 
-  .. function:: pv.color.byElement()
+  .. function:: pv.color.byElement([palette])
 
   Applies the `CPK coloring scheme <http://en.wikipedia.org/wiki/CPK_coloring>`_ to the atoms. For example, carbon atoms are colored in light-grey, oxygen in red, nitrogen in blue, sulfur in yellow.
+
+  :param palette: an optional object of colors to draw from. Include H, C, N, O, S, P. Defaults to CPK.
 
 
 .. function:: pv.color.byChain([gradient])
@@ -46,9 +48,12 @@ The following color operations are available:
   :param gradient: The graident to draw colors from. Defaults to rainbow.
   :param coilColor: The color for residues without regular secondary structure. Defaults to lightgrey.
 
-.. function:: pv.color.bySS()
+.. function:: pv.color.bySS([gradient])
 
   Colors the structure based on secondary structure type of the residue. Distinct colors are used for helices, strands and coil residues.
+
+  :param gradient: An optional gradient to draw colors from. Defaults to lightgrey, blue, green gradient.
+
 
 .. function:: pv.color.rainbow([gradient])
 

--- a/src/color.js
+++ b/src/color.js
@@ -291,7 +291,7 @@ exports.byElement = function(palette) {
 
 exports.bySS = function(grad) {
   var palette;
-  if (grad && Array.isArray(grad)) {
+  if (grad && grad._colors) {
     palette = {
       C: grad._colors[0],
       H: grad._colors[1],

--- a/src/color.js
+++ b/src/color.js
@@ -267,10 +267,10 @@ var CPK_TABLE = {
  FE : [0.56, 0.31, 0.12]
 };
 
-exports.byElement = function() {
+exports.byElement = function(palette) {
   return new ColorOp(function(atom, out, index) {
     var ele = atom.element();
-    var color = CPK_TABLE[ele];
+    var color = palette ? palette[ele] : CPK_TABLE[ele];
     if (color !== undefined) {
       out[index] = color[0]; 
       out[index+1] = color[1]; 
@@ -286,21 +286,35 @@ exports.byElement = function() {
   }, null, null);
 };
 
-exports.bySS = function() {
+exports.bySS = function(grad) {
+  var palette;
+  if (grad) {
+    palette = {
+      C: grad._colors[0],
+      H: grad._colors[1],
+      E: grad._colors[2],
+    };
+  } else {
+    palette = {
+      C: [0.8, 0.8, 0.8, 1.0],
+      H: [0.6, 0.6, 0.9, 1.0],
+      E: [0.2, 0.8, 0.2, 1.0]
+    };
+  }
 
   return new ColorOp(function(atom, out, index) {
     switch (atom.residue().ss()) {
       case 'C':
-        out[index] = 0.8;   out[index+1] = 0.8; 
-        out[index+2] = 0.8; out[index+3] = 1.0;
+        out[index] = palette.C[0];   out[index+1] = palette.C[1]; 
+        out[index+2] = palette.C[2]; out[index+3] = palette.C[3];
         return;
       case 'H':
-        out[index] = 0.6;   out[index+1] = 0.6; 
-        out[index+2] = 0.9; out[index+3] = 1.0;
+        out[index] = palette.H[0];   out[index+1] = palette.H[1]; 
+        out[index+2] = palette.H[2]; out[index+3] = palette.H[3];
         return;
       case 'E':
-        out[index] = 0.2;   out[index+1] = 0.8; 
-        out[index+2] = 0.2; out[index+3] = 1.0;
+        out[index] = palette.E[0];   out[index+1] = palette.E[1]; 
+        out[index+2] = palette.E[2]; out[index+3] = palette.E[3];
         return;
     }
   }, null, null);

--- a/src/color.js
+++ b/src/color.js
@@ -268,9 +268,12 @@ var CPK_TABLE = {
 };
 
 exports.byElement = function(palette) {
+  if (!palette) {
+    palette = CPK_TABLE;
+  }
   return new ColorOp(function(atom, out, index) {
     var ele = atom.element();
-    var color = palette ? palette[ele] : CPK_TABLE[ele];
+    var color = palette[ele];
     if (color !== undefined) {
       out[index] = color[0]; 
       out[index+1] = color[1]; 
@@ -288,12 +291,14 @@ exports.byElement = function(palette) {
 
 exports.bySS = function(grad) {
   var palette;
-  if (grad) {
+  if (grad && Array.isArray(grad)) {
     palette = {
       C: grad._colors[0],
       H: grad._colors[1],
       E: grad._colors[2],
     };
+  } else if (grad) {
+    palette = grad;
   } else {
     palette = {
       C: [0.8, 0.8, 0.8, 1.0],
@@ -303,19 +308,13 @@ exports.bySS = function(grad) {
   }
 
   return new ColorOp(function(atom, out, index) {
-    switch (atom.residue().ss()) {
-      case 'C':
-        out[index] = palette.C[0];   out[index+1] = palette.C[1]; 
-        out[index+2] = palette.C[2]; out[index+3] = palette.C[3];
-        return;
-      case 'H':
-        out[index] = palette.H[0];   out[index+1] = palette.H[1]; 
-        out[index+2] = palette.H[2]; out[index+3] = palette.H[3];
-        return;
-      case 'E':
-        out[index] = palette.E[0];   out[index+1] = palette.E[1]; 
-        out[index+2] = palette.E[2]; out[index+3] = palette.E[3];
-        return;
+    var ss = atom.residue().ss();
+    var color = palette[ss];
+    if (color !== undefined) {
+      out[index] = color[0];
+      out[index+1] = color[1]; 
+      out[index+2] = color[2];
+      out[index+3] = color[3];
     }
   }, null, null);
 };


### PR DESCRIPTION
Enable users to utilize custom colors when coloring by element (ie, high-contrast colors), or by secondary structure (ie, to highlight a particular structure).

`Color.byElement(palette)` uses an object with named elements, ie
```javascript
{ C: [0.0, 0.0, 0.0, 1.0],
  H: [0.2, 0.2, 0.2, 1.0],
  O: [1.0, 0.0, 0.0, 1.0], ...
```
`Color.bySS(grad)` uses a `gradient`, to be consistent with other coloring schemes.